### PR TITLE
 Configurações no travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,8 @@ before_install:
   - gem install bundler
 script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination site
-branches:
-  only:
-    - gh-pages
-    - master
-    - /^v.*$/
 deploy:
-  provider: rubygems
+  provider: pages
   local-dir: ./site
   email: reinangabriel1520@gmail.com
   name: Deployment Bot

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,13 @@ before_install:
   - gem install bundler
 script:
   - JEKYLL_ENV=production bundle exec jekyll build --destination site
+branches:
+  only:
+    - gh-pages
+    - master
+    - /^v.*$/
 deploy:
-  provider: pages
+  provider: rubygems
   local-dir: ./site
   email: reinangabriel1520@gmail.com
   name: Deployment Bot

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
+rvm:
+ - 2.6.5
 cache: bundler
-branches:
-  only:
-  - release
 before_install:
   - gem update --system
   - gem install bundler
@@ -11,11 +10,10 @@ script:
 deploy:
   provider: pages
   local-dir: ./site
-  target-branch: master
   email: reinangabriel1520@gmail.com
   name: Deployment Bot
   skip-cleanup: true
   github-token: $GITHUB_TOKEN
   keep-history: true
   on:
-    branch: release
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,21 @@
 language: ruby
-rvm:
-  - 2.6.5
-
+cache: bundler
+branches:
+  only:
+  - release
 before_install:
   - gem update --system
   - gem install bundler
 script:
-  - bundle install
-  - bundle exec jekyll build
-notifications:
-  email: false
-branches:
-  only:
-    - gh-pages
-    - master
-    - /^v.*$/
-
-env:
-  global:
-    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-sudo: false
-
-
+  - JEKYLL_ENV=production bundle exec jekyll build --destination site
+deploy:
+  provider: pages
+  local-dir: ./site
+  target-branch: master
+  email: reinangabriel1520@gmail.com
+  name: Deployment Bot
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  on:
+    branch: release

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
 gem 'jekyll', '~> 4.0'
+gem "json"
+gem "hash-joiner"
 
 group :jekyll_plugins do
 	gem 'jekyll-paginate'

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Projeto Kube
+[![Build Status](https://travis-ci.org/ReinanHS/projetokube-site.svg?branch=master)](https://travis-ci.org/ReinanHS/projetokube-site)
+
 # Type on Strap 
 
 [![Build Status](https://travis-ci.org/sylhare/Type-on-Strap.svg?branch=master)](https://travis-ci.org/sylhare/Type-on-Strap)

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ baseurl: #"/Type-on-Strap"
 # locale : "pt-BR"
 # default_locale: "pt-BR"
 
-url: "https://projetokube-site.github.io"
+url: "https://cbsiifslagarto.github.io/projetokube-site"
 title: Projeto Kube # site's title
 description: "Computação em nuvem, Devops e educação" # used by search engines
 

--- a/_includes/blog.html
+++ b/_includes/blog.html
@@ -3,15 +3,15 @@
     <div class="post-teaser">
         {% if post.thumbnail %}
         <div class="post-img">
-            <a aria-label="{{ post.title }}" href="{{ post.url | relative_url }}">
-                <img alt="{{ post.title }}" src="{{ post.thumbnail | relative_url }}">
+            <a aria-label="{{ post.title }}" href="{{ post.url | absolute_url }}">
+                <img alt="{{ post.title }}" src="{{ post.thumbnail | absolute_url }}">
             </a>
         </div>
         {% endif %}
         <span>
           <header>
             <h1>
-              <a aria-label="{{ post.title }}" class="post-link" href="{{ post.url | relative_url }}">
+              <a aria-label="{{ post.title }}" class="post-link" href="{{ post.url | absolute_url }}">
                 {{ post.title }}
               </a>
             </h1>

--- a/_includes/blog_nav.html
+++ b/_includes/blog_nav.html
@@ -4,13 +4,13 @@
         
         {% if paginator.previous_page and paginator.previous_page != 1%}
         <!-- << -->
-        <a aria-label="{{ site.theme_settings.str_previous_page }}" href="{{ '/' | relative_url }}" class="button">
+        <a aria-label="{{ site.theme_settings.str_previous_page }}" href="{{ '/' | absolute_url }}" class="button">
             <span><i class="fa fa-angle-double-left"></i></span>
         </a>
         {% endif %}
         
         <!-- < previous -->
-        <a aria-label="{{ site.theme_settings.str_previous_page }}" href="{{ paginator.previous_page_path | relative_url }}"
+        <a aria-label="{{ site.theme_settings.str_previous_page }}" href="{{ paginator.previous_page_path | absolute_url }}"
            {% unless paginator.previous_page %}style="visibility:hidden"{% endunless %} class="button">
             <span><i class="fa fa-chevron-left"></i></span>
             {{ site.theme_settings.str_previous_page }}
@@ -24,7 +24,7 @@
     <div class="next">
         
         <!-- next > -->
-        <a aria-label="{{ site.theme_settings.str_next_page }}" href="{{ paginator.next_page_path | relative_url }}"
+        <a aria-label="{{ site.theme_settings.str_next_page }}" href="{{ paginator.next_page_path | absolute_url }}"
            {% unless paginator.next_page %}style="visibility:hidden"{% endunless %} class="button">
             {{ site.theme_settings.str_next_page }}
             <span><i class="fa fa-chevron-right"></i></span>
@@ -32,7 +32,7 @@
 
         {% if paginator.next_page and paginator.next_page != paginator.total_pages %}
         <!-- >> -->
-        <a aria-label="{{ site.theme_settings.str_next_page }}" href="{{ site.paginate_path | relative_url | replace: ':num', paginator.total_pages }}" class="button">
+        <a aria-label="{{ site.theme_settings.str_next_page }}" href="{{ site.paginate_path | absolute_url | replace: ':num', paginator.total_pages }}" class="button">
             <span><i class="fa fa-angle-double-right"></i></span>
         </a>
         {% endif %}

--- a/_includes/gallery.html
+++ b/_includes/gallery.html
@@ -13,7 +13,7 @@ html { overflow-y: scroll; }
 {% for image in site.static_files %}
   {% if image.path contains include.gallery_path %}
     {% unless image.path contains '.md' %}
-        <img src="{{ image.path | relative_url }}" data-index="{{ forloop.index0 }}" alt="" class="grid-item" style="padding: 0;">
+        <img src="{{ image.path | absolute_url }}" data-index="{{ forloop.index0 }}" alt="" class="grid-item" style="padding: 0;">
     {% endunless %}  
   {% endif %}
 {% endfor %}
@@ -48,6 +48,6 @@ html { overflow-y: scroll; }
   <div class="pagination-total">1/5</div>
 </div>
 
-<script src="{{ "/assets/js/vendor/imagesloaded.min.js" | relative_url }}" type="text/javascript"></script>
-<script src="{{ "/assets/js/vendor/masonry.pkgd.min.js" | relative_url }}" type="text/javascript"></script>
-<script src="{{ "/assets/js/partials/gallery.js" | relative_url }}" type="text/javascript"></script>
+<script src="{{ "/assets/js/vendor/imagesloaded.min.js" | absolute_url }}" type="text/javascript"></script>
+<script src="{{ "/assets/js/vendor/masonry.pkgd.min.js" | absolute_url }}" type="text/javascript"></script>
+<script src="{{ "/assets/js/partials/gallery.js" | absolute_url }}" type="text/javascript"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,10 +3,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
     <!-- CSS -->
-    <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+    <link rel="stylesheet" href="{{ '/assets/css/main.css' | absolute_url }}">
 
     <!--Favicon-->
-    <link rel="shortcut icon" href="{{ site.theme_settings.favicon | relative_url }}" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ site.theme_settings.favicon | absolute_url }}" type="image/x-icon">
 
     <!-- Canonical -->
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
@@ -16,7 +16,7 @@
     
     {% if page.bootstrap %}
     <!-- Bootstrap-4.1.3 isolation CSS -->
-    <link rel="stylesheet" type="text/css" href="{{ '/assets/css/vendor/bootstrap-iso.min.css' | relative_url }}">
+    <link rel="stylesheet" type="text/css" href="{{ '/assets/css/vendor/bootstrap-iso.min.css' | absolute_url }}">
 
     <!-- JQuery 3.3.1 -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
@@ -29,7 +29,7 @@
     <!-- KaTeX 0.8.3 -->
     <!-- if you have any issue check https://github.com/KaTeX/KaTeX -->
     {% if site.theme_settings.katex %}
-    <script src="{{ '/assets/js/vendor/katex.min.js' | relative_url }}"></script>
+    <script src="{{ '/assets/js/vendor/katex.min.js' | absolute_url }}"></script>
     {% endif %}
 
     <!-- Google Analytics -->

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -2,13 +2,13 @@
     <!-- Logo and title -->
 	<div class="branding">
         {% if site.theme_settings.avatar %}
-		<a href="{{ '/' | relative_url }}">
-			<img alt="logo img" class="avatar" src="{{ site.theme_settings.avatar | relative_url }}" />
+		<a href="{{ '/' | absolute_url }}">
+			<img alt="logo img" class="avatar" src="{{ site.theme_settings.avatar | absolute_url }}" />
 		</a>
         {% endif %}
 
 		<h1 class="site-title">
-			<a aria-label="{{ site.title }}" href="{{ '/' | relative_url }}">
+			<a aria-label="{{ site.title }}" href="{{ '/' | absolute_url }}">
         {{ site.title }}
       </a>
 		</h1>
@@ -28,7 +28,7 @@
             {% unless page.title == null or page.hide or name_page contains page.title %}
             <li class="separator"> | </li> 
             <li>
-                <a class="clear" aria-label="{{ page.title }}" title="{{ page.title }}" href="{{ page.url | relative_url }}">
+                <a class="clear" aria-label="{{ page.title }}" title="{{ page.title }}" href="{{ page.url | absolute_url }}">
                     {% if page.icon %} <i class="fa {{ page.icon }}" aria-hidden="true"></i>
                     {% else %} {{ page.title }} {% endif%}
                 </a>

--- a/_includes/portfolio.html
+++ b/_includes/portfolio.html
@@ -3,13 +3,13 @@
 <div class="portfolio-grid">
     {% for item in site.portfolio %}
     <div class="portfolio-cell">
-        <a href="{{ item.url | relative_url }}" class="portfolio-link" data-keyboard="true">
+        <a href="{{ item.url | absolute_url }}" class="portfolio-link" data-keyboard="true">
             <div class="caption" title="{{ item.title }}">
                 <div class="caption-content">
                     <i class="fa fa-search-plus fa-3x"></i>
                 </div>
             </div>
-            <img src="{{ item.img | relative_url }}" class="" alt="">
+            <img src="{{ item.img | absolute_url }}" class="" alt="">
         </a>
     </div>
     {% endfor %}

--- a/_includes/post_info.html
+++ b/_includes/post_info.html
@@ -11,9 +11,9 @@
 {% endif %}
 
 <div class="post-info">
-  {%- if render_url -%}<a href="{{ author_url | relative_url }}" target="_blank">{%- endif -%}
+  {%- if render_url -%}<a href="{{ author_url | absolute_url }}" target="_blank">{%- endif -%}
     {% if avatar %}
-      <img src="{{ avatar | relative_url }}">
+      <img src="{{ avatar | absolute_url }}">
     {% endif %}
     <p class="meta">
       {% if author_name %}{{ author_name }} - {% endif %}{{ date | date: "%B %-d, %Y" }}

--- a/_includes/post_nav.html
+++ b/_includes/post_nav.html
@@ -1,7 +1,7 @@
 <div id="post-nav">
     {% if page.next.url %}
     <div id="previous-post">
-        <a alt="{{ page.next.title }}" href="{{ page.next.url | relative_url }}">
+        <a alt="{{ page.next.title }}" href="{{ page.next.url | absolute_url }}">
             <p>{{ site.theme_settings.str_previous_post }}</p>
             {{ page.next.title }}
         </a>
@@ -10,7 +10,7 @@
 
     {% if page.previous.url %}
     <div id="next-post">
-        <a alt="{{ page.previous.title }}" href="{{ page.previous.url | relative_url }}">
+        <a alt="{{ page.previous.title }}" href="{{ page.previous.url | absolute_url }}">
             <p>{{ site.theme_settings.str_next_post }}</p>
             {{ page.previous.title }}
         </a>

--- a/_includes/projetos.html
+++ b/_includes/projetos.html
@@ -3,13 +3,13 @@
 <div class="portfolio-grid">
     {% for item in site.projetos %}
     <div class="portfolio-cell">
-        <a href="{{ item.url | relative_url }}" class="portfolio-link" data-keyboard="true">
+        <a href="{{ item.url | absolute_url }}" class="portfolio-link" data-keyboard="true">
             <div class="caption" title="{{ item.title }}">
                 <div class="caption-content">
                     <i class="fa fa-search-plus fa-3x"></i>
                 </div>
             </div>
-            <img src="{{ item.img | relative_url }}" class="" alt="">
+            <img src="{{ item.img | absolute_url }}" class="" alt="">
         </a>
     </div>
     {% endfor %}

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -1,8 +1,8 @@
-<script src="{{ '/assets/js/vendor/jquery-1.10.2.js' | relative_url }}" type="text/javascript"></script>
-<script src="{{ '/assets/js/vendor/bootstrap.min.js' | relative_url }}" type="text/javascript"></script>
+<script src="{{ '/assets/js/vendor/jquery-1.10.2.js' | absolute_url }}" type="text/javascript"></script>
+<script src="{{ '/assets/js/vendor/bootstrap.min.js' | absolute_url }}" type="text/javascript"></script>
 
 <!-- Main JS (navbar.js, katex_init.js and masonry_init.js)-->
-<script defer=true src="{{ '/assets/js/main.min.js' | relative_url }}"></script>
+<script defer=true src="{{ '/assets/js/main.min.js' | absolute_url }}"></script>
 
 <script type="text/javascript">
     $().ready(function(){

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -10,7 +10,7 @@
 		{% endif %}		
   <div id="{{ slider.selector }}">
   {% for image in slider.images -%}
-    {% if image.href -%}<a href="{{ image.href }}">{%- endif -%}<img height="300px" data-src="{{ image.data-src | relative_url }}" data-src-2x="{{ image.data-src-2x | relative_url }}" src="{{ image.src | relative_url }}" title="{{ image.title }}" alt="{{ image.alt }}">{%- if image.href -%}</a>{% endif %}
+    {% if image.href -%}<a href="{{ image.href }}">{%- endif -%}<img height="300px" data-src="{{ image.data-src | absolute_url }}" data-src-2x="{{ image.data-src-2x | absolute_url }}" src="{{ image.src | absolute_url }}" title="{{ image.title }}" alt="{{ image.alt }}">{%- if image.href -%}</a>{% endif %}
   {% endfor -%}
   </div>
 	{% endfor %}

--- a/_includes/slider_scripts.html
+++ b/_includes/slider_scripts.html
@@ -9,9 +9,9 @@
   {%- assign iis_slider_array = iis_slider_array | concat: site_sliders | uniq -%}
 {%- endif -%}
 {% if iis_slider_array != empty %}
-  <script src="{{ "/assets/js/slider/ideal-image-slider.min.js" | relative_url }}"></script>
-  <script src="{{ "/assets/js/slider/iis-bullet-nav.js" | relative_url }}"></script>
-  <script src="{{ "/assets/js/slider/iis-captions.js" | relative_url }}"></script>
+  <script src="{{ "/assets/js/slider/ideal-image-slider.min.js" | absolute_url }}"></script>
+  <script src="{{ "/assets/js/slider/iis-bullet-nav.js" | absolute_url }}"></script>
+  <script src="{{ "/assets/js/slider/iis-captions.js" | absolute_url }}"></script>
   <script>
   {% for selector in iis_slider_array -%}	
 	{% if selector.selector  %}

--- a/_includes/slider_styles.html
+++ b/_includes/slider_styles.html
@@ -2,7 +2,7 @@
 <!-- https://github.com/jekylltools/jekyll-ideal-image-slider-include -->
 <!-- v1.8 -->
 {% if page.image_sliders or page.image_sliders.data or layout.image_sliders or page.image_sliders_load_all -%}
-<link rel="stylesheet" href="{{ "/assets/css/slider/ideal-image-slider.css" | relative_url }}">
-<link rel="stylesheet" href="{{ "/assets/css/slider/themes/default.css" | relative_url }}">
+<link rel="stylesheet" href="{{ "/assets/css/slider/ideal-image-slider.css" | absolute_url }}">
+<link rel="stylesheet" href="{{ "/assets/css/slider/themes/default.css" | absolute_url }}">
 {%- endif -%}
  

--- a/_includes/tags_list.html
+++ b/_includes/tags_list.html
@@ -10,7 +10,7 @@
     {% endif %}
 
     {% for tag in tags %}
-    <a class="button" href="{{ "/tags" | relative_url }}#{{ tag | cgi_escape }}">
+    <a class="button" href="{{ "/tags" | absolute_url }}#{{ tag | cgi_escape }}">
       <p><i class="fa fa-tag fa-fw"></i> {{ tag }}</p>
     </a>
     {% endfor %}

--- a/_includes/user_card.html
+++ b/_includes/user_card.html
@@ -2,11 +2,11 @@
 	<div class="card">
 		<div class="front">
 			<div class="cover">
-				<img src="{{ '/assets/img/pexels/computer.jpeg' | relative_url }}"/>
+				<img src="{{ '/assets/img/pexels/computer.jpeg' | absolute_url }}"/>
 			</div>
 			<div class="user">
 				{% if user.avatar %}
-				<img class="img-circle" src="{{ user.avatar | relative_url }}"/>
+				<img class="img-circle" src="{{ user.avatar | absolute_url }}"/>
 				{% elsif user.github %}
 				<img class="img-circle" src="https://avatars3.githubusercontent.com/{{ user.github }}?v=3&amp;s=273"/>
 				{% else %}


### PR DESCRIPTION
1. Configurando o Travis CI para criar e implantar o site

Devemos criar uma conta no Travis CI para sincronizar nosso repositório GitHub com o Travis, então temos que procurar o repositório no Travis e depois clicar com o botão direito para ativar esse repositório.

![Projeto](https://miro.medium.com/max/1675/1*BwypOVhSR_DcGHRjrZI7BA.png)

Depois disso precisamos adicionar um token do GitHub para o Travis CI para poder publicar o site gerado. Vá para [Github Token](https://github.com/settings/tokens) e crie um token de acesso pessoal.

![Projeto](https://miro.medium.com/max/2815/1*5fOAumDl3XCWD0h-Vhtfcw.png)

Depois de gerar seu token, copie-o imediatamente, pois ele só estará disponível apenas quando é criado. Leve esse token copiado de volta à página Configurações no Travis CI, crie uma variável de ambiente chamada GITHUB_TOKEN, cole o token no campo value, verifique se “Exibir valor no log de criação” não está marcado e clique em Adicionar.

2. Mudando a branch do GithubPage

O travis-ci cria uma branch para a compilação do jekyll chamada de gh-pages, então devemos informar ao Github que essa branch é a nossa página que ficarar no site. Clique em Settings e depois procure por GitHub Pages e mude a branch para gh-pages 

Houve um problema com a **URL** porque na compilação com a opção `relative_url ` ficava sem o domínio do site em todos os links ( **CSS** , **JS** e etc.. com isso as páginas não carregavam ) e com a opção `absolute_url` que pegava a configuração que está em `_config.yml`: 
`url: https://cbsiifslagarto.github.io/projetokube-site`
e substituir quando for compilado pelo travis-ci. 

Isso não é bem um erro mais eu penso que não é a melhor forma. Porém, foi a única maneira que encontrei para corrigir o erro que não estava carregando os **CSS** e **JS**.