### PR TITLE
Correção de erro do menu nos celulares não abrir

### DIFF
--- a/_includes/script.html
+++ b/_includes/script.html
@@ -2,4 +2,5 @@
 <script src="{{ 'assets/js/vendor/popper.min.js' | absolute_url}}"></script>
 <script src="{{ 'assets/js/vendor/bootstrap.min.js' | absolute_url}}"></script>
 <script src="{{ 'assets/js/app.js' | absolute_url}}"></script>
+<script src="{{ 'assets/js/main.min.js' | absolute_url}}"></script>
 {% include slider_scripts.html %}


### PR DESCRIPTION
No último Pull Request com a atualização do layout faltou adicionar o script main.min.js

Esse script é responsável por fazer com que o menu fique disponível para celulares e dispositivos móveis