### PR TITLE
Solução para erro na paginação

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :jekyll_plugins do
 	
 	gem 'jekyll-toc'
 	gem "premonition", "~> 2.0.0"
-	gem "jekyll-paginate-v2"
+	gem "jekyll-paginate-v2", "~> 1.5.2" 
 end
 
 # gem 'jekyll-git-updated'


### PR DESCRIPTION
Foi adicionado uma versão específica para o plugin de paginação. Pois, existe uma incompatibilidade nas versões do meu ambiente de desenvolvimento e a versão final.

A versão 1.5.2 foi a que usei para a lógica da paginação do site, porém nas versões futuras do plugin mudou bastante, gerando uma incompatibilidade com a lógica que foi implementada por mim então resolvi deixar a versão 1.5.2 com uma versão específica para o plugin já que ela funciona perfeitamente.